### PR TITLE
improve the use of go routines.

### DIFF
--- a/pkg/dbsyncers/policy_syncer.go
+++ b/pkg/dbsyncers/policy_syncer.go
@@ -31,22 +31,28 @@ type policyDBSyncer struct {
 }
 
 func (syncer *policyDBSyncer) Start(stopChannel <-chan struct{}) error {
-	ticker := time.NewTicker(syncer.syncInterval)
-
 	ctx, cancelContext := context.WithCancel(context.Background())
 	defer cancelContext()
 
+	go syncer.periodicSync(ctx)
+
+	<-stopChannel // blocking wait for stop event
+	syncer.log.Info("stop performing sync", "table", syncer.tableName)
+
+	return nil // context cancel is called before exiting this function
+}
+
+func (syncer *policyDBSyncer) periodicSync(ctx context.Context) {
+	ticker := time.NewTicker(syncer.syncInterval)
+
 	for {
 		select {
-		case <-stopChannel:
+		case <-ctx.Done(): // we have received a signal to stop
 			ticker.Stop()
+			return
 
-			syncer.log.Info("stop performing sync", "table", syncer.tableName)
-			cancelContext()
-
-			return nil
 		case <-ticker.C:
-			go syncer.sync(ctx)
+			syncer.sync(ctx)
 		}
 	}
 }

--- a/pkg/dbsyncers/policy_syncer.go
+++ b/pkg/dbsyncers/policy_syncer.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	dbEnumCompliant    = "compliant"
-	dbEnumNonCompliant = "non_compliant"
+	dbEnumCompliant          = "compliant"
+	dbEnumNonCompliant       = "non_compliant"
+	timeoutInIntervalPeriods = 3
 )
 
 type policyDBSyncer struct {
@@ -52,7 +53,9 @@ func (syncer *policyDBSyncer) periodicSync(ctx context.Context) {
 			return
 
 		case <-ticker.C:
-			syncer.sync(ctx)
+			ctxWithTimeout, cancelFunc := context.WithTimeout(ctx, syncer.syncInterval*timeoutInIntervalPeriods)
+			syncer.sync(ctxWithTimeout)
+			cancelFunc() // cancel only child ctx and is used to cleanup resources once context expires or sync is done.
 		}
 	}
 }


### PR DESCRIPTION
we should always have the main go routine keep listening to stop signal
separated the functions and created a periodicSync which is running in a single go routine
instead of invoking a new routine every cycle with no reason

Signed-off-by: Nir Rozenbaum <nirro@il.ibm.com>